### PR TITLE
chore: require Node 22+ and drop Node 20 from CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         os: [ubuntu-latest, windows-latest, macos-latest]
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A simple command-line tool that compiles a Node.js program into single executable binary that runs without Node.js runtime installed, built on top of the Node.js [single executable application](https://nodejs.org/docs/latest/api/single-executable-applications.html) (SEA) feature.
 
 > [!NOTE]
-> The Node.js SEA feature is currently still experimental according to [the official document](https://nodejs.org/docs/latest-v20.x/api/single-executable-applications.html).
+> The Node.js SEA feature is currently still experimental according to [the official document](https://nodejs.org/docs/latest/api/single-executable-applications.html).
 > And seac is super experimental.
 
 ## Installation
@@ -32,7 +32,7 @@ seac hello.js hello
 
 ## Limitations
 
-- Requires Node.js v20 or higher
+- Requires Node.js v22 or higher
 - Only CommonJS is supported. ESM is not supported yet by the Node.js SEA feature.
 
 ## Prior art

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "typescript": "^5.3.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@biomejs/biome": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.2.1",
   "bin": "dist/cli.js",
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary

Node.js 20 reached end-of-life. Align `engines`, documentation, and CI with **Node 22+**.

## Changes

- **CI**: `node.js.yml` matrix from `[20.x, 22.x, 24.x]` to `[22.x, 24.x]`.
- **package.json / lockfile**: `engines.node` set to `>= 22`.
- **README**: point SEA docs at unversioned latest; require Node v22+ in limitations.

## Note

Raising `engines` is a breaking change for anyone still on Node 20. Consider a semver bump on release if you treat engines strictly.

Made with [Cursor](https://cursor.com)